### PR TITLE
Automatic update of NuGet.CommandLine to 4.9.3

### DIFF
--- a/Nethereum.Worbooks.Tests/Nethereum.Worbooks.Tests/Nethereum.Worbooks.Tests.csproj
+++ b/Nethereum.Worbooks.Tests/Nethereum.Worbooks.Tests/Nethereum.Worbooks.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Nethereum.Web3" Version="3.0.0" />
     <PackageReference Include="NuGet.Client" Version="4.3.0-beta1-2418" />
-    <PackageReference Include="NuGet.CommandLine" Version="4.7.1">
+    <PackageReference Include="NuGet.CommandLine" Version="4.9.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
NuKeeper has generated a minor update of `NuGet.CommandLine` to `4.9.3` from `4.7.1`
`NuGet.CommandLine 4.9.3` was published at `2019-02-13T21:40:50Z`, 15 days ago

2 project updates:
Updated `Nethereum.Worbooks.Tests/Nethereum.Worbooks.Tests/Nethereum.Worbooks.Tests.csproj` to `NuGet.CommandLine` `4.9.3` from `4.7.1`
Updated `Nethereum.Worbooks.Tests/Updater/packages.config` to `NuGet.CommandLine` `4.9.3` from `4.7.1`

[NuGet.CommandLine 4.9.3 on NuGet.org](https://www.nuget.org/packages/NuGet.CommandLine/4.9.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
